### PR TITLE
add: Two-column-mode for wide landscape-mode screens

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,18 +7,24 @@
 
 <div style="position: absolute; width: 100%;">
   <div class="panel">
-      <h1 class="center">TINF22F: Studienjahr 3</h1>
-      <h4 class="center">Wichtige DHBW-Seiten</h4>
+    <h1 class="center">TINF22F: Studienjahr 3</h1>
+    <h3 class="center">Wichtige DHBW-Seiten</h3>
+    <div>
       <app-links *ngFor="let item of dhbwLinks" [data]="item"></app-links>
+    </div>
   </div>
-  
+
   <div class="panel">
-      <h4 class="center">Module</h4>
+    <h3 class="center">Module</h3>
+    <div>
       <app-links *ngFor="let item of moduleLinks" [data]="item"></app-links>
+    </div>
   </div>
-  
+
   <div class="panel">
-      <h4 class="center">Github</h4>
+    <h3 class="center">Github</h3>
+    <div>
       <app-links *ngFor="let item of githubLinks" [data]="item"></app-links>
+    </div>
   </div>
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,20 +1,22 @@
 .center {
-    text-align: center;
-    color: rgb(83, 83, 83);
+  text-align: center;
+  color: rgb(83, 83, 83);
 }
 
 .panel {
-    width: 55%;
-    margin-left: 22.5%;
-    background: #eee;
-    border-radius: 4px;
-    box-sizing: border-box;
-    background: rgb(255, 255, 255);
-    background: rgba(255, 255, 255, 0.4);
-    padding-top: 10px;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
-    margin-top: 20px;
+  width: 80%;
+  margin-inline: auto;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.4);
+  padding: 1rem;
+  margin-block: 2rem;
+
+  div {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    column-gap: 1rem;
+    row-gap: 0.5rem;
+  }
 }
 
 .panel span {
@@ -23,9 +25,13 @@
 
 }
 
-@media only screen and (max-width: 500px) {
-  .panel{
+@media only screen and (max-width: 768px) {
+  .panel {
     width: 90%;
-    margin-left: 5%;
+
+    div {
+      display: flex;
+      flex-direction: column;
+    }
   }
 }

--- a/src/app/links/links.component.scss
+++ b/src/app/links/links.component.scss
@@ -1,10 +1,7 @@
 
-
 * {
-    width: 95%;
-    margin-left: 2.5%;
-    margin-top: 10px;
-    background-color: white!important;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    font-size: 1.05rem;
+  width: 100%;
+  background-color: white !important;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1.05rem;
 }


### PR DESCRIPTION
This pr adds support for displaying the links in two columns on landscape-mode screens, so no scrolling is necessary in order to view all links.
| old | new |
| ---- | -------- |
| ![image](https://github.com/user-attachments/assets/721f0673-1eae-4c9c-a168-8d27076d13c7)| ![image](https://github.com/user-attachments/assets/189e91a8-f851-45e9-80dd-3b8496e20edf) |

